### PR TITLE
Added exclusion of URL paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 ## Changelog
 
+1.2.0 Added the possibility to print something in <head> on the excluded paths.
 1.1.0 Started the changelog. Added exclusion of paths.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## Version
+
+1.0.0 Started version numbering. Added exclusion of paths.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-## Version
+## Changelog
 
-1.0.0 Started version numbering. Added exclusion of paths.
+1.1.0 Started the changelog. Added exclusion of paths.

--- a/admin/plugin-page.php
+++ b/admin/plugin-page.php
@@ -5,6 +5,8 @@
 
 $gtm_id 						= get_option( 'grain_data_gtm_id', '' );
 $gd_excluded_paths				= get_option( 'grain_data_excluded_paths', '' );
+$gd_excluded_head				= get_option( 'grain_data_excluded_head', '' );
+$gd_excluded_head_content		= get_option( 'grain_data_excluded_head_content', '' );
 $gd_attributes_page_variables 	= get_option( 'grain_data_attributes_page_variables', array() );
 $pageVariableOptions 			= unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
 ?>
@@ -57,9 +59,19 @@ $pageVariableOptions 			= unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONF
 				}
 				?>
 
-				<h3>Excluded paths</h3>
-				<input type="text" name="gd_excluded_paths" value="<?php echo $gd_excluded_paths; ?>" class="regular-text" />
-				<p class="description">Voeg hier paden toe die niet naar de cookie wall moeten leiden. Voeg deze toe komma gescheiden, begin met een slash, eindig zonder slash, geen spaties. Bijv. /pad/pad-pad/,/pad</p>
+				<div>
+					<h3>Excluded paths</h3>
+					<input type="text" name="gd_excluded_paths" value="<?php echo $gd_excluded_paths; ?>" class="regular-text" />
+					<p class="description">Voeg hier paden toe die niet naar de cookie wall moeten leiden. Voeg deze toe komma gescheiden, begin met een slash, eindig zonder slash, geen spaties. Bijv. /pad/pad-pad/,/pad</p>
+				</div>
+
+				<div>
+					<input type="checkbox" id="gd_excluded_head" name="gd_excluded_head" value="1" <?php echo checked( $gd_excluded_head, 1 ); ?>>
+					<label for="gd_excluded_head">In plaats hiervan druk dit af in &lt;head&gt;:</label>
+					<div>
+						<textarea name="gd_excluded_head_content" rows="10" cols="80" class="code"><?php echo $gd_excluded_head_content; ?></textarea>
+					</div>
+				</div>
 
 				<input class="button btn btn-success" name="save_page_variables" type="submit" value="Save" />
 			</form>

--- a/admin/plugin-page.php
+++ b/admin/plugin-page.php
@@ -1,9 +1,12 @@
 <?php
-	//Get the value of the data_track_page_enabled
-	$data_track_page_enabled = get_option( 'grain_data_track_page_enabled', false );
-	$gtm_id = get_option( 'grain_data_gtm_id', '' );
-	$grain_data_attributes_page_variables = get_option( 'grain_data_attributes_page_variables', array() );
-	$pageVariableOptions = unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
+/**
+ * Save the options.
+ */
+
+$gtm_id 						= get_option( 'grain_data_gtm_id', '' );
+$gd_excluded_paths				= get_option( 'grain_data_excluded_paths', '' );
+$gd_attributes_page_variables 	= get_option( 'grain_data_attributes_page_variables', array() );
+$pageVariableOptions 			= unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
 ?>
 <div class="container-fluid wrap">
 	<div class="row">
@@ -16,96 +19,50 @@
 	<form action="" method="post">
 		<div class="row">
 			<div class="col-2">
-				<div class="form-group">
-					<label for="gtmID">Google Tag Manager ID</label>
-					<input name="gtmID" type="text" class="form-control" id="gtmID" value="<?php echo $gtm_id; ?>">
-				</div>
-			</div>
-			<div class="col-2">
-				<label for="gtmID">&nbsp;</label>
-				<input
-					name="save_gtm_id"
-					type="submit"
-					class="button btn btn-success form-control"
-					value="Save GTM ID" />
 			</div>
 		</div>
 	</form>
 
-	<div class="row">
+	<div class="row mt-4" >
 		<div class="col">
-			<h2>Page variables</h2>
-			<button
-				id="enablePageVariablesButton"
-				style="display:none"
-				class="button btn btn-success">
-				Enable page variables
-			</button>
-			<input
-				id="disablePageVariablesButton"
-				name="disable_page_variables"
-				type="submit"
-				style="display:none"
-				class="button btn btn-danger"
-				value="Disable page variables" />
-		</div>
-	</div>
-
-	<div class="row mt-4" id="pageVariableOptions" style="display:none">
-		<div class="col">
-			<h3>Options</h3>
-
 			<form name="pageVariableForm" action="" method="post">
-			<?php
-			foreach ( $pageVariableOptions as $key => $options ) {
-			?>
-				<h3><?php echo esc_html( ucfirst( $key ) ); ?></h3>
+
+				<h3>Google Tag Manager ID</h3>
+
+				<div class="form-group">
+					<label for="gtmID">Google Tag Manager ID</label>
+					<input name="gtmID" type="text" class="form-control" id="gtmID" value="<?php echo $gtm_id; ?>">
+				</div>
+
+				<h3>Options</h3>
+
 				<?php
-				foreach ( $options as $value ) {
+				foreach ( $pageVariableOptions as $key => $options ) {
 				?>
+					<h3><?php echo esc_html( ucfirst( $key ) ); ?></h3>
+					<?php
+					foreach ( $options as $value ) {
+					?>
 				<div class="form-check">
 					<input
 						type="checkbox"
 						class="form-control"
 						name="<?php echo $value ?>"
 						id="<?php echo $value ?>"
-						<?php echo ( isset( $grain_data_attributes_page_variables[$key][$value] ) && $grain_data_attributes_page_variables[$key][$value] ) ? 'checked="checked"' : '' ; ?> />
+						<?php echo ( isset( $gd_attributes_page_variables[$key][$value] ) && $gd_attributes_page_variables[$key][$value] ) ? 'checked="checked"' : '' ; ?> />
 					<label for="<?php echo $value ?>"><?php echo $value ?></label>
 				</div>
-			<?php
+				<?php
+					}
 				}
-			}
-			?>
-				<input class="button btn btn-success" name="save_page_variables" type="submit" value='Save options' />
+				?>
+
+				<h3>Excluded paths</h3>
+				<input type="text" name="gd_excluded_paths" value="<?php echo $gd_excluded_paths; ?>" class="regular-text" />
+				<p class="description">Voeg hier paden toe die niet naar de cookie wall moeten leiden. Voeg deze toe komma gescheiden, begin met een slash, eindig zonder slash, geen spaties. Bijv. /pad/pad-pad/,/pad</p>
+
+				<input class="button btn btn-success" name="save_page_variables" type="submit" value="Save" />
 			</form>
 		</div>
 	</div>
 </div>
-
-<script>
-(function( $ ) {
-	$( window ).load(function() {
-		var dataTackPageEnabled = <?php echo ( $data_track_page_enabled ) ? 'true' : 'false' ;?>;
-
-		if (dataTackPageEnabled) {
-			enablePageVariables();
-		} else {
-			disablePageVariables();
-		}
-
-		function enablePageVariables() {
-			$('#disablePageVariablesButton').show();
-			$('#enablePageVariablesButton').hide();
-			$('#pageVariableOptions').show();
-		}
-
-		function disablePageVariables() {
-			$('#enablePageVariablesButton').show();
-			$('#disablePageVariablesButton').hide();
-			$('#pageVariableOptions').hide();
-		}
-
-		$('#enablePageVariablesButton').on( 'click', enablePageVariables );
-	});
-})( jQuery );
-</script>

--- a/admin/save-plugin-options.php
+++ b/admin/save-plugin-options.php
@@ -2,25 +2,38 @@
 /**
  * Saves the options.
  */
-if ( $_POST['save_page_variables'] ) {
-	$pageVariableOptions = unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
 
-	$pageVariableConfiguration = array();
-	foreach( $pageVariableOptions as $key => $options ) {
-		foreach( $options as $value ) {
-			$pageVariableConfiguration[$key][$value] = isset( $_POST[$value]) ? true : false;
+if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+	if ( $_POST['save_page_variables'] ) {
+		$pageVariableOptions = unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
+
+		$pageVariableConfiguration = array();
+		foreach( $pageVariableOptions as $key => $options ) {
+			foreach( $options as $value ) {
+				$pageVariableConfiguration[$key][$value] = isset( $_POST[$value]) ? true : false;
+			}
 		}
+
+		update_option( 'grain_data_track_page_enabled', true );
+		update_option( 'grain_data_attributes_page_variables', $pageVariableConfiguration );
 	}
 
-	update_option( 'grain_data_track_page_enabled', true );
-	update_option( 'grain_data_attributes_page_variables', $pageVariableConfiguration );
-}
+	if ( isset( $_POST['gtmID'] ) )  {
+		update_option( 'grain_data_gtm_id', $_POST['gtmID'] );
+	}
 
-if ( isset( $_POST['gtmID'] ) )  {
-	update_option( 'grain_data_gtm_id', $_POST['gtmID'] );
-}
+	if ( isset( $_POST['gd_excluded_paths'] ) ) {
+		update_option( 'grain_data_excluded_paths', $_POST['gd_excluded_paths'] );
+	}
 
-if ( isset( $_POST['gd_excluded_paths'] ) ) {
-	update_option( 'grain_data_excluded_paths', $_POST['gd_excluded_paths'] );
+	if ( isset( $_POST['gd_excluded_head'] ) ) {
+		update_option( 'grain_data_excluded_head', 1 );
+	} else {
+		delete_option( 'grain_data_excluded_head' );
+	}
+
+	if ( isset( $_POST['gd_excluded_head_content'] ) ) {
+		update_option( 'grain_data_excluded_head_content', $_POST['gd_excluded_head_content'] );
+	}
 }
 ?>

--- a/admin/save-plugin-options.php
+++ b/admin/save-plugin-options.php
@@ -1,26 +1,26 @@
 <?php
-	/**
-	 * Saves the options.
-	 */
-	if ( isset( $_POST['save_page_variables'] ) ) {
-		$pageVariableOptions = unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
+/**
+ * Saves the options.
+ */
+if ( $_POST['save_page_variables'] ) {
+	$pageVariableOptions = unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
 
-		$pageVariableConfiguration = array();
-		foreach( $pageVariableOptions as $key => $options ) {
-			foreach( $options as $value ) {
-				$pageVariableConfiguration[$key][$value] = isset( $_POST[$value] ) ? true : false;
-			}
+	$pageVariableConfiguration = array();
+	foreach( $pageVariableOptions as $key => $options ) {
+		foreach( $options as $value ) {
+			$pageVariableConfiguration[$key][$value] = isset( $_POST[$value]) ? true : false;
 		}
-
-		update_option( 'grain_data_track_page_enabled', true );
-		update_option( 'grain_data_attributes_page_variables', $pageVariableConfiguration );
 	}
 
-	if ( isset( $_POST['disable_page_variables'] ) ) {
-		update_option( 'grain_data_track_page_enabled', false );
-	}
+	update_option( 'grain_data_track_page_enabled', true );
+	update_option( 'grain_data_attributes_page_variables', $pageVariableConfiguration );
+}
 
-	if ( isset( $_POST['save_gtm_id'] ) ) {
-		update_option( 'grain_data_gtm_id', $_POST['gtmID'] );
-	}
+if ( isset( $_POST['gtmID'] ) )  {
+	update_option( 'grain_data_gtm_id', $_POST['gtmID'] );
+}
+
+if ( isset( $_POST['gd_excluded_paths'] ) ) {
+	update_option( 'grain_data_excluded_paths', $_POST['gd_excluded_paths'] );
+}
 ?>

--- a/front/add_attributes.php
+++ b/front/add_attributes.php
@@ -1,120 +1,163 @@
 <?php
-// Adds the variable dataTrackPageVariables to the current page source.
-function gda_add_attributes() {
-	$pageVariableOptions = unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
-	$data_track_page = array();
-	$data_track_page_enabled = get_option( 'grain_data_track_page_enabled', 'False' );
-	$gtm_id = get_option( 'grain_data_gtm_id', "" );
-	$grain_data_attributes_page_variables = get_option( 'grain_data_attributes_page_variables', array() );
-
-	if ( $gtm_id !== '' ) {
-		$gtmCode = "
-			<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-			})(window,document,'script','dataLayer','". $gtm_id ."');</script>
-		";
-	   echo $gtmCode;
+/**
+ * Prints Google Tag Manager code.
+ */
+class GD_Attributes_Frontend {
+	function __construct() {
+		add_action( 'wp_footer', array( $this, 'print_attributes' ) );
 	}
 
-	if ( $data_track_page_enabled === 'False' ) {
-		return false;
-	}
+	// Adds the variable dataTrackPageVariables to the current page source.
+	public function print_attributes() {
+		$pageVariableOptions 			= unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
+		$data_track_page 				= array();
+		$gtm_id 						= get_option( 'grain_data_gtm_id', '' );
+		$gd_attributes_page_variables 	= get_option( 'grain_data_attributes_page_variables', array() );
 
-	$current_user = wp_get_current_user();
-	foreach ( $pageVariableOptions as $key => $options ) {
-		foreach ( $options as $option ) {
-			if ( $grain_data_attributes_page_variables[$key][$option] ) {
-				// Only add this when on a single.
-				if ( is_single() ) {
-					switch( $option ) {
-						case 'postPublishDate':
-							$data_track_page[$option] = get_the_date('c');
-							break;
-						case 'postID':
-							$data_track_page[$option] = get_the_ID();
-							break;
-						case 'postAuthorID':
-							$data_track_page[$option] = get_the_author_meta( 'ID' );
-							break;
-						case 'postCategories':
-							$categories = get_the_category();
-							$category_data = array();
-							$category_data_ids = array();
-							$category_data_names = array();
-							foreach ( $categories as $category ) {
-								$category_data[] = array(
-									'id' => $category->term_id,
-									'name' => $category->name,
-								);
-								$category_data_ids[] = $category->term_id;
-								$category_data_names[] = $category->name;
-							}
-							$data_track_page[$option] = $category_data;
-							$data_track_page['postCategoriesIDs'] = $category_data_ids;
-							$data_track_page['postCategoriesNames'] = $category_data_names;
-							break;
-						case 'postTags':
-							$tags = get_the_tags();
-							if ( $tags ) {
-								$tag_data = array();
-								$tag_data_ids = array();
-								$tag_data_names = array();
-								foreach ( $tags as $tag ) {
-									$tag_data[] = array(
-										'id' => $tag->term_id,
-										'name' => $tag->name,
+		// If the current slug is an excluded one print nothing.
+		if ( $this->is_excluded_slug() ) {
+			return;
+		}
+
+		// If there is no gtm_id then print nothing.
+		if ( empty( $gtm_id ) ) {
+			return;
+		} else {
+			$gtmCode = "
+				<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+				new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+				j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+				'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+				})(window,document,'script','dataLayer','". $gtm_id ."');</script>
+			";
+		   echo $gtmCode;
+		}
+
+		$current_user = wp_get_current_user();
+
+		foreach ( $pageVariableOptions as $key => $options ) {
+			foreach ( $options as $option ) {
+				if ( $gd_attributes_page_variables[$key][$option] ) {
+					// Only add this when on a single.
+					if ( is_single() ) {
+						switch( $option ) {
+							case 'postPublishDate':
+								$data_track_page[$option] = get_the_date('c');
+								break;
+							case 'postID':
+								$data_track_page[$option] = get_the_ID();
+								break;
+							case 'postAuthorID':
+								$data_track_page[$option] = get_the_author_meta( 'ID' );
+								break;
+							case 'postCategories':
+								$categories = get_the_category();
+								$category_data = array();
+								$category_data_ids = array();
+								$category_data_names = array();
+								foreach ( $categories as $category ) {
+									$category_data[] = array(
+										'id' => $category->term_id,
+										'name' => $category->name,
 									);
-									$tag_data_ids[] = $tag->term_id;
-									$tag_data_names[] = $tag->name;
+									$category_data_ids[] = $category->term_id;
+									$category_data_names[] = $category->name;
 								}
-								$data_track_page[$option] = $tag_data;
-								$data_track_page['postTagsIDs'] = $tag_data_ids;
-								$data_track_page['postTagsNames'] = $tag_data_names;
-							} else {
-								$data_track_page[$option] = '';
-							}
-							break;
+								$data_track_page[$option] = $category_data;
+								$data_track_page['postCategoriesIDs'] = $category_data_ids;
+								$data_track_page['postCategoriesNames'] = $category_data_names;
+								break;
+							case 'postTags':
+								$tags = get_the_tags();
+								if ( $tags ) {
+									$tag_data = array();
+									$tag_data_ids = array();
+									$tag_data_names = array();
+									foreach ( $tags as $tag ) {
+										$tag_data[] = array(
+											'id' => $tag->term_id,
+											'name' => $tag->name,
+										);
+										$tag_data_ids[] = $tag->term_id;
+										$tag_data_names[] = $tag->name;
+									}
+									$data_track_page[$option] = $tag_data;
+									$data_track_page['postTagsIDs'] = $tag_data_ids;
+									$data_track_page['postTagsNames'] = $tag_data_names;
+								} else {
+									$data_track_page[$option] = '';
+								}
+								break;
+						}
 					}
-				}
 
-				// Always add these.
-				switch( $option ) {
-					case 'isLoggedIn':
-						$data_track_page[$option] = ( is_user_logged_in() ) ? '1' : '0' ;
+					// Always add these.
+					switch( $option ) {
+						case 'isLoggedIn':
+							$data_track_page[$option] = ( is_user_logged_in() ) ? '1' : '0' ;
+							break;
+						case 'userRole':
+							$data_track_page[$option] = ( is_user_logged_in() ) ?  $current_user->roles[0] : '';
+							break;
+						case 'email':
+							$data_track_page[$option] = ( is_user_logged_in() ) ? $current_user->user_email : '';
+							break;
+						case 'wordPressUserID':
+							$data_track_page[$option] = ( is_user_logged_in() ) ? $current_user->ID : '';
 						break;
-					case 'userRole':
-						$data_track_page[$option] = ( is_user_logged_in() ) ?  $current_user->roles[0] : '';
-						break;
-					case 'email':
-						$data_track_page[$option] = ( is_user_logged_in() ) ? $current_user->user_email : '';
-						break;
-					case 'wordPressUserID':
-						$data_track_page[$option] = ( is_user_logged_in() ) ? $current_user->ID : '';
-					break;
+					}
 				}
 			}
 		}
+
+		$data_track_page = apply_filters( 'customize_data_track_page', $data_track_page );
+
+		if ( empty( $data_track_page ) ) {
+			$data_track_page = "{}";
+		} else {
+			$data_track_page = json_encode( $data_track_page );
+		}
+
+		$addDataTrackPage = "
+			<script>
+				var body = document.querySelector(\"body\");
+				var dataTrackPageVariables = ". $data_track_page .";
+				body.setAttribute(\"data-track-page\", JSON.stringify(dataTrackPageVariables));
+			</script>
+		";
+	   echo $addDataTrackPage;
 	}
 
-	$data_track_page = apply_filters( 'customize_data_track_page', $data_track_page );
+	/**
+	 * Checks if the current REQUEST_URI is in the option 'grain_data_excluded_paths'.
+	 * @return boolean True if REQUEST_URI is in 'grain_data_excluded_paths', false otherwise.
+	 */
+	function is_excluded_slug() {
+		$excluded_paths	= get_option( 'grain_data_excluded_paths', '' );
+		if ( empty( trim( $excluded_paths ) ) ) {
+			return false;
+		}
 
-	if ( empty( $data_track_page ) ) {
-		$data_track_page = "{}";
-	} else {
-		$data_track_page = json_encode( $data_track_page );
+		$excluded_paths = explode( ',', $excluded_paths );
+
+		// Remove spaces.
+		$excluded_paths = array_map( 'trim', $excluded_paths );
+
+		// Make sure all values are lowercase.
+		$excluded_paths = array_map( 'strtolower', $excluded_paths );
+
+		// Get the REQUEST URI and only that. We don't want a trailing slash.
+		$url_parts = parse_url( $_SERVER['REQUEST_URI'] );
+		$slug = strtolower( rtrim( $url_parts['path'], '/' ) );
+
+		// Check if REQUEST URI is in the excludes paths.
+		if ( in_array( $slug, $excluded_paths ) ) {
+			return true;
+		}
+
+		return false;
 	}
-
-	$addDataTrackPage = "
-		<script>
-			var body = document.querySelector(\"body\");
-			var dataTrackPageVariables = ". $data_track_page .";
-			body.setAttribute(\"data-track-page\", JSON.stringify(dataTrackPageVariables));
-		</script>
-	";
-   echo $addDataTrackPage;
 }
 
-add_action( 'wp_footer', 'gda_add_attributes' );
+$gd_attributes_frontend = new GD_Attributes_Frontend();
 ?>

--- a/front/add_attributes.php
+++ b/front/add_attributes.php
@@ -4,10 +4,30 @@
  */
 class GD_Attributes_Frontend {
 	function __construct() {
+		add_action( 'wp_head', array( $this, 'wp_head' ) );
 		add_action( 'wp_footer', array( $this, 'print_attributes' ) );
 	}
 
-	// Adds the variable dataTrackPageVariables to the current page source.
+	/**
+	 * wp_head filter
+	 */
+	public function wp_head() {
+		// Print something in the header or not on the excluded paths.
+		if ( $this->is_excluded_slug() ) {
+			$gd_excluded_head = get_option( 'grain_data_excluded_head', 0 );
+
+			if ( $gd_excluded_head ) {
+				$gd_excluded_head_content = get_option( 'grain_data_excluded_head_content', '' );
+				if ( $gd_excluded_head_content ) {
+					 echo $gd_excluded_head_content . "\r\n";
+				}
+			}
+		}
+	}
+
+	/**
+	 * Adds the variable dataTrackPageVariables to the current page source.
+	 */
 	public function print_attributes() {
 		$pageVariableOptions 			= unserialize( GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG );
 		$data_track_page 				= array();

--- a/grain-data-attributes.php
+++ b/grain-data-attributes.php
@@ -1,9 +1,8 @@
 <?php
-
 /*
 Plugin Name: Grain Data Attributes
 Description: This plug-in adds the data-attributes for the Grain Data Tracking Framework using Google Tag Manager.
-Version: 1.1.0
+Version: 1.2.0
 */
 
 // Set some global variables
@@ -32,18 +31,6 @@ define ( 'GRAIN_DATA_ATTRIBUTES_PAGE_VARIABLES_CONFIG',  serialize(
 // Require files
 require_once( 'admin/save-plugin-options.php' );
 require_once( 'front/add_attributes.php' );
-
-// We need Bootstrap for our plugin, so we require it in this function
-function bootstrap_jquery_scripts() {
-	// wp_enqueue_style( 'grain_data_attributes_bootstrap_css', GRAIN_DATA_ATTRIBUTES_URL . '/admin/assets/vendors/bootstrap/bootstrap.min.css', false );
-	// wp_enqueue_script( 'grain_data_attributes_bootstrap_js', GRAIN_DATA_ATTRIBUTES_URL . '/admin/assets/vendors/bootstrap/bootstrap.min.js', false );
-}
-add_action( 'admin_enqueue_scripts', 'bootstrap_jquery_scripts' );
-
-// We also have additional scripts to use for our own functionality
-/*function grain_data_attributes_scripts() {
-}
-add_action( 'admin_enqueue_scripts', 'grain_data_attributes_scripts' );*/
 
 function add_admin_menu_page() {
 	// The menu page will only be showed when the user has the "manage_options" role. The show_grain_data_attributes_page function is called to show the page

--- a/grain-data-attributes.php
+++ b/grain-data-attributes.php
@@ -2,8 +2,8 @@
 
 /*
 Plugin Name: Grain Data Attributes
-Version: 1.0.1
 Description: This plug-in adds the data-attributes for the Grain Data Tracking Framework using Google Tag Manager.
+Version: 1.1.0
 */
 
 // Set some global variables


### PR DESCRIPTION
Url paths can be added in the backend and on pages with those URL paths the GTM code doesn't get printed. This was needed due to GDPR.