### PR TITLE
Fixed saving of the option 'grain_data_excluded_head'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 ## Changelog
 
+1.2.1 Fixed saving of the option *grain_data_excluded_head*.
+
 1.2.0 Added the possibility to print something in <head> on the excluded paths.
+
 1.1.0 Started the changelog. Added exclusion of paths.

--- a/admin/save-plugin-options.php
+++ b/admin/save-plugin-options.php
@@ -29,7 +29,7 @@ if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
 	if ( isset( $_POST['gd_excluded_head'] ) ) {
 		update_option( 'grain_data_excluded_head', 1 );
 	} else {
-		delete_option( 'grain_data_excluded_head' );
+		update_option( 'grain_data_excluded_head', 0 );
 	}
 
 	if ( isset( $_POST['gd_excluded_head_content'] ) ) {

--- a/grain-data-attributes.php
+++ b/grain-data-attributes.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Grain Data Attributes
 Description: This plug-in adds the data-attributes for the Grain Data Tracking Framework using Google Tag Manager.
-Version: 1.2.0
+Version: 1.2.1
 */
 
 // Set some global variables


### PR DESCRIPTION
@JosIJntema Zou deze aanpassing in jullie repo gemergt kunnen worden? Het opslaan van een optie werkte niet en wordt hiermee verholpen.